### PR TITLE
fix: missing opacity on disabled button ab#35419 

### DIFF
--- a/.changeset/two-ideas-battle.md
+++ b/.changeset/two-ideas-battle.md
@@ -1,0 +1,5 @@
+---
+"@arbeidstilsynet/design-css": patch
+---
+
+Fix missing opacity on disabled button

--- a/packages/css/src/filepicker.css
+++ b/packages/css/src/filepicker.css
@@ -88,7 +88,7 @@
   gap: var(--ds-size-1);
   align-items: center;
 
-  padding: var(--ds-size-2) var(--ds-size-2);
+  padding: var(--ds-size-2);
   border: var(--ds-border-width-default) solid var(--ds-color-border-default);
 
   &--error {

--- a/packages/css/src/filepicker.css
+++ b/packages/css/src/filepicker.css
@@ -4,10 +4,6 @@
   width: 100%;
   max-width: 43rem;
   gap: var(--ds-size-1);
-
-  &[data-disabled="true"] .at-filepicker-dropzone {
-    opacity: var(--ds-disabled-opacity);
-  }
 }
 
 .at-filepicker-dropzone-wrapper {

--- a/packages/css/src/filepicker.css
+++ b/packages/css/src/filepicker.css
@@ -5,8 +5,7 @@
   max-width: 43rem;
   gap: var(--ds-size-1);
 
-  &[data-disabled="true"] .at-filepicker-dropzone,
-  &[data-disabled="true"] .at-filepicker-file__remove {
+  &[data-disabled="true"] .at-filepicker-dropzone {
     opacity: var(--ds-disabled-opacity);
   }
 }

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -3,3 +3,13 @@
 @import "./filepicker.css" layer(at.components);
 @import "./header.css" layer(at.components);
 @import "./lightdarklogo.css" layer(at.components);
+
+/* Workaround for upstream token rename
+/* "Rename --ds-disabled-opacity to --ds-opacity-disabled"
+/* https://github.com/digdir/designsystemet/pull/3250
+*/
+
+/* Alias old name -> new name */
+:where(:root) {
+  --ds-opacity-disabled: var(--ds-disabled-opacity);
+}


### PR DESCRIPTION
Workaround for old token name. Remove when Figma is fixed.