### PR TITLE
chore: remove duplicate changeset

### DIFF
--- a/.changeset/renovate-98e05b2.md
+++ b/.changeset/renovate-98e05b2.md
@@ -1,5 +1,0 @@
----
-'@arbeidstilsynet/design-react': patch
----
-
-Updated dependency `react-dropzone` to `^14.4.1`.


### PR DESCRIPTION
`./scripts/dedupe-changelog.ts` didn't handle this correctly, removing the newer `^15.0.0` duplicate instead. Should fix script later.