### PR TITLE
fix(css): fix active ToggleGroup styles

### DIFF
--- a/.changeset/free-wombats-deny.md
+++ b/.changeset/free-wombats-deny.md
@@ -1,0 +1,5 @@
+---
+"@arbeidstilsynet/design-css": patch
+---
+
+**ToggleGroup**: fix missing active styles

--- a/apps/storybook/stories/digdir/ToggleGroup.stories.tsx
+++ b/apps/storybook/stories/digdir/ToggleGroup.stories.tsx
@@ -42,25 +42,30 @@ export const Preview: StoryFn<typeof ToggleGroup> = (args) => {
 };
 
 Preview.args = {
+  "data-toggle-group": "Filtering", // Set data-toggle-group attribute for accessibility
   defaultValue: "innboks",
   name: "toggle-group-nuts",
 };
 
-export const OnlyIcons: StoryFn<typeof ToggleGroup> = () => {
+export const OnlyIcons: StoryFn<typeof ToggleGroup> = (args) => {
   return (
-    <ToggleGroup defaultValue={"option-1"}>
+    <ToggleGroup
+      {...args}
+      data-toggle-group="Tekstjustering"
+      defaultValue="option-1"
+    >
       <Tooltip content="Venstrestilt">
-        <ToggleGroup.Item value="option-1" icon>
+        <ToggleGroup.Item value="option-1">
           <AlignLeftIcon title="AlignLeftIcon" />
         </ToggleGroup.Item>
       </Tooltip>
       <Tooltip content="Midtstilt">
-        <ToggleGroup.Item value="option-2" icon>
+        <ToggleGroup.Item value="option-2">
           <AlignCenterIcon title="AlignCenterIcon" />
         </ToggleGroup.Item>
       </Tooltip>
       <Tooltip content="Høyrestilt">
-        <ToggleGroup.Item value="option-3" icon>
+        <ToggleGroup.Item value="option-3">
           <AlignRightIcon title="AlignRightIcon" />
         </ToggleGroup.Item>
       </Tooltip>
@@ -72,7 +77,11 @@ export const Kontrollert: StoryFn<typeof ToggleGroup> = () => {
   const [value, setValue] = useState<string>("utkast");
   return (
     <>
-      <ToggleGroup value={value} onChange={setValue}>
+      <ToggleGroup
+        data-toggle-group="Filtering"
+        value={value}
+        onChange={setValue}
+      >
         <ToggleGroup.Item value="innboks">
           <EnvelopeClosedIcon aria-hidden />
           Innboks
@@ -96,5 +105,48 @@ export const Kontrollert: StoryFn<typeof ToggleGroup> = () => {
         Velg Arkiv
       </Button>
     </>
+  );
+};
+export const Secondary = Preview.bind({});
+Secondary.args = {
+  "data-toggle-group": "Filtering", // Set data-toggle-group attribute for accessibility
+  defaultValue: "innboks",
+  variant: "secondary",
+};
+
+export const SecondaryOnlyIcons = OnlyIcons.bind({});
+SecondaryOnlyIcons.args = {
+  "data-toggle-group": "Filtering", // Set data-toggle-group attribute for accessibility
+  variant: "secondary",
+};
+
+export const Disabled: StoryFn<typeof ToggleGroup> = () => {
+  return (
+    <ToggleGroup>
+      <ToggleGroup.Item value="innboks">Innboks</ToggleGroup.Item>
+      <ToggleGroup.Item disabled value="utkast">
+        Utkast
+      </ToggleGroup.Item>
+      <ToggleGroup.Item disabled value="arkiv">
+        Arkiv
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="Søppelpost">Søppelpost</ToggleGroup.Item>
+      <ToggleGroup.Item value="sendt">Sendt</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};
+export const AriaDisabled: StoryFn<typeof ToggleGroup> = () => {
+  return (
+    <ToggleGroup>
+      <ToggleGroup.Item value="innboks">Innboks</ToggleGroup.Item>
+      <ToggleGroup.Item aria-disabled="true" value="utkast">
+        Utkast
+      </ToggleGroup.Item>
+      <ToggleGroup.Item aria-disabled="true" value="arkiv">
+        Arkiv
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="Søppelpost">Søppelpost</ToggleGroup.Item>
+      <ToggleGroup.Item value="sendt">Sendt</ToggleGroup.Item>
+    </ToggleGroup>
   );
 };

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -30,8 +30,10 @@
   /* Don't apply when inside Pagination.
    Pagination currently has mixed docs of either setting data-variant="primary" on Pagination.Button
     or keeping it as tertiary (returned from usePagination). If this is changed upstream we can simplify this selector.
+
+    Also don't apply when inside ToggleGroup, which uses <label class="ds-button" data-variant="tertiary">
   */
-    .ds-pagination .ds-button[data-variant="tertiary"]
+    :is(.ds-pagination, .ds-toggle-group) .ds-button[data-variant="tertiary"]
   ) {
   /** Text **/
   --dsc-button-color: var(--ds-color-text-default);


### PR DESCRIPTION
Similar bug as #731

Updated stories from upstream, but there is some weird jank with styling not working for the autodocs version of Preview. All the stories work by themselves. Unclear if the root issue will affect (only uncontrolled?) downstream.