### PR TITLE
chore(prek): enable oxlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # install JS plugins used by oxlint
+      - uses: Arbeidstilsynet/action-pnpm-setup@72d8b6a4a6492697599795caf6bf6d3862474946 # v1
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2
 
   typecheck:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: Arbeidstilsynet/action-pnpm-setup@72d8b6a4a6492697599795caf6bf6d3862474946 # v1
       - run: pnpm build
 
-  lint-test:
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -44,7 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: Arbeidstilsynet/action-pnpm-setup@72d8b6a4a6492697599795caf6bf6d3862474946 # v1
-      - run: pnpm lint
       - run: pnpm test
         id: test
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,6 @@ repos:
     hooks:
       - id: oxlint
         verbose: true
-        # running oxlint on all files is much faster locally
-        # than passing filenames and starting several instances of oxlint
-        always_run: true
-        pass_filenames: false
-        entry: oxlint .
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt
     rev: v0.50.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,16 @@ repos:
       - id: end-of-file-fixer
         exclude: ^(.*\.svg|design-tokens/.*)$
 
-  # wait for fix to windows OOM issue, run lint through pnpm meanwhile
-  # https://github.com/oxc-project/oxc/issues/20513#issuecomment-4308308087
-  # - repo: https://github.com/oxc-project/mirrors-oxlint
-  #   rev: v1.62.0
-  #   hooks:
-  #     - id: oxlint
-  #       verbose: true
+  - repo: https://github.com/oxc-project/mirrors-oxlint
+    rev: v1.65.0
+    hooks:
+      - id: oxlint
+        verbose: true
+        # running oxlint on all files is much faster locally
+        # than passing filenames and starting several instances of oxlint
+        always_run: true
+        pass_filenames: false
+        entry: oxlint .
 
   - repo: https://github.com/oxc-project/mirrors-oxfmt
     rev: v0.50.0

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format:check": "oxfmt --check",
     "typecheck": "tsc -b",
     "typecheck:scripts": "tsc --project scripts",
-    "lint": "pnpm -r lint",
+    "lint": "oxlint .",
     "dev": "pnpm storybook",
     "test": "vitest run",
     "build": "pnpm -r build",

--- a/scripts/dedupe-changelog.ts
+++ b/scripts/dedupe-changelog.ts
@@ -249,7 +249,7 @@ export function dedupeChangelog(pkg: string): {
     // Create a signature for this entry based on the packages it updates
     const packageSignature = entry.dependencies
       .map((d) => d.packageName)
-      .sort((a, b) => a.localeCompare(b))
+      .toSorted((a, b) => a.localeCompare(b))
       .join(",");
 
     if (!packageSetGroups.has(packageSignature)) {

--- a/scripts/dedupe-changelog.ts
+++ b/scripts/dedupe-changelog.ts
@@ -43,7 +43,7 @@ const packagesDir = path.resolve(process.cwd(), "packages");
 
 function parseVersion(version: string): number[] {
   // Strip version range specifiers (^, ~, >, <, >=, <=, =)
-  const cleanedVersion = version.replace(/^[\^~><>=]*/, "");
+  const cleanedVersion = version.replace(/^[\^~<>=]*/, "");
   return cleanedVersion.split(".").map((v) => Number.parseInt(v, 10));
 }
 


### PR DESCRIPTION
Windows OOM issue that triggered in prek was fixed in v1.65 https://github.com/oxc-project/oxc/releases/tag/apps_v1.65.0

Keeping package.json lint scripts for easy use locally. Fixed root script only running for react and storybook packages.