### PR TITLE
fix: enforce LF line endings to prevent phantom changes after commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
## Problem

On Windows, `* text=auto` in `.gitattributes` causes git to check out files with CRLF line endings. When pre-commit hooks run (specifically `oxfmt`), files are rewritten with LF. After the commit succeeds, git sees the working-tree files (LF) differ from the expected checkout (CRLF) and reports them as modified.

Trying to stage these changes causes them to disappear - git normalizes both sides to LF in the index and sees no actual diff.

## Fix

Adding `eol=lf` to `.gitattributes` forces LF on checkout across all platforms, matching what `oxfmt` and other tools produce.

## After merging

Existing clones may show a one-time batch of phantom changes. Run:```git checkout -- .```