### PR TITLE
feat(css): override Link component styles to match Gnist design

### DIFF
--- a/.changeset/link-override.md
+++ b/.changeset/link-override.md
@@ -1,0 +1,5 @@
+---
+'@arbeidstilsynet/design-css': patch
+---
+
+Override Link component styles to match updated Gnist design. Changes default text color from `text-subtle` to `text-default`, hover color to `base-hover`, and visited color to match default.

--- a/.changeset/link-override.md
+++ b/.changeset/link-override.md
@@ -2,4 +2,4 @@
 '@arbeidstilsynet/design-css': patch
 ---
 
-Override Link component styles to match updated Gnist design. Changes default text color from `text-subtle` to `text-default`, hover color to `base-hover`, and visited color to match default.
+**Link**: Override styles to match updated Gnist design. Changes default text color from `text-subtle` to `text-default`, hover color to `base-hover`, and visited color to match default.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,13 @@ Note: Figma designs may refer to colors as "main" — this corresponds to the "a
 
 Use [Changesets](https://github.com/changesets/changesets). Run `pnpm changeset` after making changes to generate a changeset file. CI handles versioning and publishing to npm.
 
+Changeset descriptions must follow the format: `**ComponentName**: description of change`. For example:
+
+```
+**Link**: Override styles to match updated Gnist design.
+**Header**: Remove hardcoded header height in mobile view.
+```
+
 ### Design tokens
 
 Tokens are managed in Figma via Tokens Studio plugin and synced to the `design-tokens/` directory. Run `pnpm tokens:build` to regenerate theme CSS from tokens. See `docs/TOKENS.md` for full workflow.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,18 @@ Custom components extend `DefaultProps<TRef>` which provides `ref`, `data-size`,
 - Use Designsystemet CSS custom properties (`--ds-*`) for tokens
 - Add container queries for responsive behavior
 
+### Color system (Designsystemet)
+
+Designsystemet uses **contextual semantic color tokens**. Generic tokens like `--ds-color-text-default` or `--ds-color-base-hover` resolve to different values based on the current `data-color` attribute on the element or its ancestors.
+
+- By default (`:root`, `[data-color="accent"]`), generic tokens map to accent palette values (e.g., `--ds-color-text-default` → `--ds-color-accent-text-default`).
+- When `data-color="neutral"` is set, the same generic tokens map to neutral palette values (e.g., `--ds-color-text-default` → `--ds-color-neutral-text-default`).
+- This applies to all color palettes: accent, neutral, danger, success, info, warning, and any custom ones.
+
+**When writing CSS overrides for Digdir components, prefer the generic semantic tokens** (`--ds-color-text-default`, `--ds-color-base-hover`, etc.) over palette-specific tokens (`--ds-color-accent-text-default`, `--ds-color-neutral-text-default`). The generic tokens automatically adapt to the current color context, so a single override rule works for all color variants.
+
+Note: Figma designs may refer to colors as "main" — this corresponds to the "accent" palette / default color context in code.
+
 ### Testing
 
 - Framework: Vitest with happy-dom environment

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "inputs": [],
+  "servers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/apps/storybook/stories/Overrides.mdx
+++ b/apps/storybook/stories/Overrides.mdx
@@ -11,3 +11,11 @@ In some cases, we need to override styles of base components from the design sys
 ### Button
 
 Overwritten default styles (colors and padding)
+
+### Link
+
+Overwritten default styles:
+
+- **Default color**: `text-subtle` → `text-default`
+- **Hover color**: `text-default` → `base-hover`
+- **Visited color**: uses default color instead of browser visited color

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -1,6 +1,7 @@
 @import "@digdir/designsystemet-css/dist/src/index.css";
 
 @import "./button.css" layer(at.overrides);
+@import "./link.css" layer(at.overrides);
 
 @import "./filepicker.css" layer(at.components);
 @import "./header.css" layer(at.components);

--- a/packages/css/src/link.css
+++ b/packages/css/src/link.css
@@ -1,0 +1,8 @@
+/** Overrides the default link styles to match Gnist design. */
+
+.ds-link {
+  /** Text **/
+  --dsc-link-color: var(--ds-color-text-default);
+  --dsc-link-color--hover: var(--ds-color-base-hover);
+  --dsc-link-color--visited: var(--dsc-link-color);
+}


### PR DESCRIPTION
## Summary

Override Digdir Link component default/hover/visited colors using CSS custom properties in the `at.overrides` layer, matching the updated Figma specs from issue #581.

### Changes

| State | Before (Digdir default) | After (Gnist override) |
|---|---|---|
| **Default** | `text-subtle` | `text-default` |
| **Hover** | `text-default` | `base-hover` |
| **Visited** | `visited` | `text-default` (same as default) |

### Files changed

- **`packages/css/src/link.css`** — New file: overrides `--dsc-link-color`, `--dsc-link-color--hover`, and `--dsc-link-color--visited` on `.ds-link`
- **`packages/css/src/index.css`** — Imports `link.css` in the `at.overrides` layer
- **`.github/copilot-instructions.md`** — Documents the Designsystemet color token system
- **`.changeset/link-override.md`** — Patch changeset for `@arbeidstilsynet/design-css`

### Affected components

All components using `.ds-link` will pick up the new colors automatically:
- **Link** (direct)
- **BreadcrumbsLink** (wraps Link)
- **ErrorSummaryLink** (wraps Link with `data-color="neutral"`)
- **FilePicker** (uses Link for file downloads)
- **Header** — unaffected, has its own scoped overrides in `at.components` layer

### Approach

Follows the same pattern as the existing Button override (`button.css`): override Digdir CSS custom properties in the `at.overrides` layer. Uses generic semantic tokens (`--ds-color-text-default`, `--ds-color-base-hover`) which resolve contextually per `data-color` attribute, so a single rule handles both accent and neutral variants.

Closes #581
