### PR TITLE
chore: scaffold agent skills config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,3 +106,17 @@ Changeset descriptions must follow the format: `**ComponentName**: description o
 ### Design tokens
 
 Tokens are managed in Figma via Tokens Studio plugin and synced to the `design-tokens/` directory. Run `pnpm tokens:build` to regenerate theme CSS from tokens. See `docs/TOKENS.md` for full workflow.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues for `Arbeidstilsynet/design`, via the `gh` CLI. Note: many issues are Figma-driven and managed by designers until they are dev-ready. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-role vocabulary; the `triage` skill is optional here since incoming work is largely designer-managed. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `docs/adr/` at the repo root (no `CONTEXT.md` yet). See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo: one (optional) `CONTEXT.md` plus `docs/adr/` at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root (not present yet — proceed silently if absent).
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. This repo's ADRs are named `adr-NNNN-<slug>.md` (e.g. `adr-0001-repo-init.md`, `adr-0003-digdir-komponenter.md`), with `adr-0000-template.md` as the template.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md            ← optional; not present yet
+├── docs/adr/
+│   ├── adr-0000-template.md
+│   ├── adr-0001-repo-init.md
+│   ├── adr-0002-pakkeversjonering.md
+│   └── adr-0003-digdir-komponenter.md
+└── packages/ , apps/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md` if/when it exists. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0003 (digdir-komponenter) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,24 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `Arbeidstilsynet/design`. Use the `gh` CLI for all operations.
+
+> Workflow note: many issues are Figma-driven and primarily managed by designers until they are ready for development. Treat designer-owned issues as out of scope for automated triage unless they are explicitly marked dev-ready.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+> Note: triage here is largely handled by designers, who manage Figma-driven issues until they are dev-ready. The `triage` skill is optional for this repo. This table exists so that, if used, labels match the repo's vocabulary instead of creating duplicates.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Scaffolds the per-repo configuration the engineering skills expect.

## Changes
- Add `## Agent skills` section to `.github/copilot-instructions.md` (kept in the existing Copilot instructions file rather than creating CLAUDE.md/AGENTS.md).
- Add `docs/agents/issue-tracker.md` — GitHub Issues via `gh`, noting issues are Figma/designer-driven until dev-ready.
- Add `docs/agents/triage-labels.md` — default five-role triage label map (triage skill optional here).
- Add `docs/agents/domain.md` — single-context layout pointing at `docs/adr/`.

No product code changed.